### PR TITLE
Add fullscreenChange event

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ $carousel.flickity('toggleFullscreen');
 flkty.toggleFullscreen();
 ```
 
+## Events
+
+### fullscreenChange
+
+Triggered after entering or exiting the fullscreen view. 
+
+``` js
+// jQuery
+$carousel.on( 'fullscreenChange.flickity', function( event, isFullscreen ) {...} );
+
+// vanilla JS
+flkty.on( 'fullscreenChange', function( event, isFullscreen ) {...} );
+```
+
+  - `event` · _Event_ · the `event` object
+  - `isFullscreen` · _boolean_ · state after change
+  
 ---
 
 By [Metafizzy](https://metafizzy.co) 🌈🐻

--- a/fullscreen.js
+++ b/fullscreen.js
@@ -86,6 +86,7 @@ proto._changeFullscreen = function( isView ) {
   if ( this.isFullscreen ) {
     this.reposition();
   }
+  this.dispatchEvent( 'fullscreenChange', null, [ isView ] );
 };
 
 proto.toggleFullscreen = function() {


### PR DESCRIPTION
I have added a `fullscreenChange` event. A boolean `isFullscreen` status is sent along to the handler.

Just observing clicks on the fullscreen button didn't work well, particularly in iOS (frequently failed to fire). This is cleaner, and just a single line anyway.