### PR TITLE
Set flickity as peerDependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Enable fullscreen view of Flickity carousels",
   "main": "fullscreen.js",
   "style": "fullscreen.css",
-  "dependencies": {
+  "peerDependencies": {
     "flickity": "^2.1.0"
   },
   "scripts": {


### PR DESCRIPTION
## Scenario
Combining `flickity` with multiples plugins, like `flickity-fullscreen` and `flickity-as-nav-for`.

## Issue
Since we have `flickity` as a dependency, will extend flickity from it's own `node_modules` instead of extending the one of the project's `node_modules`.

This makes impossible to combine two plugins.

## Solution
Define on the plugin, `flickity` as a `peerDependency`.

--

If you merge this, we should do the same on https://github.com/metafizzy/flickity-as-nav-for